### PR TITLE
fixed profile variable error.

### DIFF
--- a/terraform/dev/elasticsearch/elasticsearch.tf
+++ b/terraform/dev/elasticsearch/elasticsearch.tf
@@ -1,6 +1,6 @@
 provider "aws" {
-  region = "us-east-1"
-  profile = "elastic"
+  region = "${var.region}"
+  profile = "${var.aws_profile}"
 }
 
 module "elasticsearch" {

--- a/terraform/dev/lambda/lambda.tf
+++ b/terraform/dev/lambda/lambda.tf
@@ -1,6 +1,6 @@
 provider "aws" {
-  region = "us-east-1"
-  profile = "elastic"
+  region = "${var.region}"
+  profile = "${var.aws_profile}"
 }
 
 module "lambda" {

--- a/terraform/dev/s3/s3.tf
+++ b/terraform/dev/s3/s3.tf
@@ -1,6 +1,6 @@
 provider "aws" {
-  region = "us-east-1"
-  profile = "elastic"
+  region = "${var.region}"
+  profile = "${var.aws_profile}"
 }
 
 module "s3" {


### PR DESCRIPTION
This caused the error of my credentials not matching the configured AWS profile. The profile variables where static, not using the variable from the conf file.